### PR TITLE
[HOTFIX] 로그인 API 연동 오류 수정

### DIFF
--- a/src/shared/apis/apiClient.ts
+++ b/src/shared/apis/apiClient.ts
@@ -23,6 +23,7 @@ const apiClient: AxiosInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true, // HttpOnly Cookie 사용을 위한 설정
 });
 
 /**
@@ -52,9 +53,16 @@ const refreshAccessToken = async (): Promise<string | null> => {
       return null;
     }
 
-    const response = await axios.post('/api/v1/auth/refresh-token', {
-      refreshToken,
-    });
+    const response = await axios.post(
+      '/api/v1/auth/refresh',
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${refreshToken}`,
+        },
+        withCredentials: true,
+      }
+    );
 
     if (response.data.isSuccess && response.data.details) {
       const { accessToken, refreshToken: newRefreshToken, expiresAt } = response.data.details;
@@ -94,8 +102,14 @@ apiClient.interceptors.response.use(
       _retry?: boolean;
     };
 
-    // 401 에러이고 재시도하지 않은 요청인 경우
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    // 인증 관련 API는 재시도하지 않음 (로그인, 회원가입, 토큰 갱신 등)
+    const authEndpoints = ['/api/v1/auth/login', '/api/v1/auth/register', '/api/v1/auth/refresh'];
+    const isAuthEndpoint = authEndpoints.some((endpoint) =>
+      originalRequest.url?.includes(endpoint)
+    );
+
+    // 401 에러이고 재시도하지 않은 요청이며, 인증 API가 아닌 경우
+    if (error.response?.status === 401 && !originalRequest._retry && !isAuthEndpoint) {
       if (isRefreshing) {
         // 이미 토큰 갱신 중인 경우, 대기
         return new Promise((resolve) => {
@@ -123,7 +137,7 @@ apiClient.interceptors.response.use(
       } else {
         // 리프레시 토큰도 만료된 경우, 로그인 페이지로 이동
         clearTokens();
-        window.location.href = '/login';
+        window.location.href = '/auth';
         return Promise.reject(error);
       }
     }

--- a/src/shared/apis/auth.api.ts
+++ b/src/shared/apis/auth.api.ts
@@ -99,8 +99,13 @@ export const refreshToken = async (
   data: RefreshTokenRequest
 ): Promise<ApiResponse<RefreshTokenResponse>> => {
   const response = await apiClient.post<ApiResponse<RefreshTokenResponse>>(
-    '/api/v1/auth/refresh-token',
-    data
+    '/api/v1/auth/refresh',
+    {},
+    {
+      headers: {
+        Authorization: `Bearer ${data.refreshToken}`,
+      },
+    }
   );
 
   // 토큰 갱신 성공 시 새 토큰 저장

--- a/src/shared/router/ProtectedRoute.tsx
+++ b/src/shared/router/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import { Navigate } from 'react-router-dom';
+import { isLoggedIn } from '../utils/tokenManager';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+/**
+ * 인증이 필요한 라우트를 보호하는 컴포넌트
+ * - 로그인되지 않은 경우 /auth 페이지로 리다이렉트
+ */
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  if (!isLoggedIn()) {
+    return <Navigate to="/auth" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION

## 📝 작업 내용
- axios에 withCredentials 설정 추가 (HttpOnly Cookie 지원)
- refresh token 엔드포인트 경로 수정 (/refresh-token → /refresh)
- refresh token 요청 방식 변경 (body → Authorization 헤더)
- 로그인/회원가입 API의 401 에러는 재시도하지 않도록 수정
- ProtectedRoute 컴포넌트 추가 (인증 보호 기능)

<br/>

## 📢 PR Point

- 

<br/>

## 이미지 첨부


<br/>

## 🔧 다음 할 일

- 다음 할 일을 적어주세요

<br/> 