### PR TITLE
Fix : ts 버전 업데이트에 따른 baseurl 필드 지원종료 예정 -> 해당 라인 삭제

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -16,7 +16,6 @@
     "jsx": "react-jsx",
 
     /* Path Alias */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     },


### PR DESCRIPTION
## 📝 작업 내용

- ts 버전 업데이트에 따른 baseurl 필드 지원종료 예정에 의하여 경고문구가 발생하였습니다. 이에 해당 라인 삭제하였습니다.

<br/>

## 📢 PR Point

- 

<br/>

## 이미지 첨부


<br/>

## 🔧 다음 할 일

- 다음 할 일을 적어주세요

<br/> 